### PR TITLE
normalization kernels are kept during cleanup.

### DIFF
--- a/src/jtorch/spatial_divisive_normalization.cpp
+++ b/src/jtorch/spatial_divisive_normalization.cpp
@@ -42,12 +42,12 @@ namespace jtorch {
 
   SpatialDivisiveNormalization::~SpatialDivisiveNormalization() {
     cleanup();
+	SAFE_DELETE(kernel_);
+	SAFE_DELETE(kernel_norm_);
   }
 
   void SpatialDivisiveNormalization::cleanup() {
-    SAFE_DELETE(output);
-    SAFE_DELETE(kernel_);
-    SAFE_DELETE(kernel_norm_);
+    SAFE_DELETE(output);    
     SAFE_DELETE(std_coef_);
     SAFE_DELETE(std_pass1_);
     SAFE_DELETE(std_pass2_);

--- a/src/jtorch/spatial_subtractive_normalization.cpp
+++ b/src/jtorch/spatial_subtractive_normalization.cpp
@@ -51,7 +51,6 @@ namespace jtorch {
 
   void SpatialSubtractiveNormalization::cleanup() {
     SAFE_DELETE(output);
-    SAFE_DELETE(kernel_);
     SAFE_DELETE(mean_coef_);
     SAFE_DELETE(mean_pass1_);
     SAFE_DELETE(mean_pass2_);


### PR DESCRIPTION
A bug when different sized images are fed to spatial normalization
modules.